### PR TITLE
fix: changed delete message on list pages and increased excerpt limit to 5000 characters

### DIFF
--- a/src/pages/categories/components/CategoryList.js
+++ b/src/pages/categories/components/CategoryList.js
@@ -77,7 +77,7 @@ function CategoryList({ actions }) {
               </Button>
             </Link>
             <Popconfirm
-              title="Sure to cancel?"
+              title="Sure to Delete?"
               onConfirm={() => dispatch(deleteCategory(record.id)).then(() => fetchCategories())}
             >
               <Link to="" className="ant-dropdown-link">

--- a/src/pages/posts/components/PostForm.js
+++ b/src/pages/posts/components/PostForm.js
@@ -109,7 +109,7 @@ function PostForm({ onCreate, data = {} }) {
                 name="excerpt"
                 rules={[
                   { min: 3, message: 'Title must be minimum 3 characters.' },
-                  { max: 300, message: 'Title must be maximum 300 characters.' },
+                  { max: 5000, message: 'Excerpt must be a maximum of 5000 characters.' },
                 ]}
               >
                 <Input.TextArea


### PR DESCRIPTION
fix #148 fix #149

1. #148 Changed the delete message on list pages from "Sure to cancel?" to "Sure to Delete?"

2. #149 Increased the limit on the excerpt from 300 characters to 5000 characters and changed the message to "Excerpt must be a maximum of 5000 characters."