### PR TITLE
see menu based on permissions

### DIFF
--- a/src/components/GlobalNav/Sidebar.js
+++ b/src/components/GlobalNav/Sidebar.js
@@ -8,6 +8,7 @@ const { Sider } = Layout;
 const { SubMenu } = Menu;
 
 function Sidebar({ superOrg, permission, orgs, loading }) {
+  const [showCoreMenu, setCoreMenu] = useState(false);
   const { navTheme } = useSelector((state) => state.settings);
   const [collapsed, setCollapsed] = useState(false);
   const onCollapse = () => {
@@ -43,7 +44,13 @@ function Sidebar({ superOrg, permission, orgs, loading }) {
   permission.forEach((each) => {
     if (each.resource === 'admin') {
       resource = resource.concat(protectedResouces);
+      if( !showCoreMenu ) {
+        setCoreMenu(true);
+      }
     } else {
+      if( !showCoreMenu && protectedResouces.includes(each.resource)) {
+        setCoreMenu(true);
+      }
       resource.push(each.resource);
     }
   });
@@ -91,21 +98,24 @@ function Sidebar({ superOrg, permission, orgs, loading }) {
         {sidebarMenu.map((menu, index) => {
           const { Icon } = menu;
           return (
+            (menu.title === 'CORE' && !showCoreMenu) ? null : ( 
             <SubMenu key={index} title={menu.title} icon={<Icon />}>
               {menu.submenu && menu.submenu.length > 0 ? (
                 <>
-                  {menu.submenu[0].isAdmin === superOrg.is_admin ? (
+                  {(menu.submenu[0].isAdmin === superOrg.is_admin && orgs[0]?.permission.role === 'owner')? (
                     <SubMenu key={menu.submenu[0].title + index} title={menu.submenu[0].title}>
                       {getMenuItems(menu.submenu[0].children, index, menu.submenu[0].title)}
                     </SubMenu>
                   ) : null}
+                  { orgs[0]?.permission.role === 'owner' ?  (
                   <SubMenu key={menu.submenu[1].title + index} title={menu.submenu[1].title}>
                     {getMenuItems(menu.submenu[1].children, index, menu.submenu[1].title)}
                   </SubMenu>
+                  ) : null }
                 </>
               ) : null}
               {getMenuItems(menu.children, index, menu.title)}
-            </SubMenu>
+            </SubMenu> )
           );
         })}
       </Menu>

--- a/src/pages/dashboard/index.js
+++ b/src/pages/dashboard/index.js
@@ -1,12 +1,16 @@
 import React from 'react';
 import { Space, Typography } from 'antd';
 import Features from './components/Features';
+import getUserPermission from '../../utils/getUserPermission';
+import { useSelector } from 'react-redux';
 
 function Dashboard() {
+  const spaces = useSelector(({ spaces }) => spaces);
+  const actions = getUserPermission({ resource: 'dashboard', action: 'get', spaces });
   return (
     <Space direction="vertical">
       <Typography.Title>Dashboard</Typography.Title>
-      <Features />
+      {actions.includes('admin') ? <Features /> : null}
     </Space>
   );
 }


### PR DESCRIPTION
User should not see core menu until they get permission to any one entity of core.
Organisation menu-item should not show up for super org members.
Option to create default entities should not show up if user doesn't have permission.
Closes #167 